### PR TITLE
Skip assigning axes in MouseManipulator if already assigned programmatically

### DIFF
--- a/Source/OxyPlot/PlotController/Manipulators/MouseManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/MouseManipulator.cs
@@ -34,7 +34,8 @@ namespace OxyPlot
         /// <param name="e">The <see cref="OxyInputEventArgs" /> instance containing the event data.</param>
         public override void Started(OxyMouseEventArgs e)
         {
-            this.AssignAxes(e.Position);
+            if (this.XAxis == null || this.YAxis == null)
+                this.AssignAxes(e.Position);
             base.Started(e);
             this.StartPosition = e.Position;
         }

--- a/Source/OxyPlot/PlotController/Manipulators/PlotManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/PlotManipulator.cs
@@ -37,13 +37,13 @@ namespace OxyPlot
         /// Gets or sets the X axis.
         /// </summary>
         /// <value>The X axis.</value>
-        protected Axis XAxis { get; set; }
+        public Axis XAxis { get; set; }
 
         /// <summary>
         /// Gets or sets the Y axis.
         /// </summary>
         /// <value>The Y axis.</value>
-        protected Axis YAxis { get; set; }
+        public Axis YAxis { get; set; }
 
         /// <summary>
         /// Transforms a point from screen coordinates to data coordinates.


### PR DESCRIPTION
Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-

@oxyplot/admins
